### PR TITLE
support many-to-many api endpoints

### DIFF
--- a/src/load_routes.js
+++ b/src/load_routes.js
@@ -8,7 +8,7 @@ const defineRoute = (verb, route, implementation) => ({verb, route, implementati
 const defineSubscribers = (subscribers, key) =>
   _.filter(subscribers, s => s.subscribe && s.subscribe(key));
 
-const defineRoutes = (prefix, key, schema, database, subscribers) => {
+const defineRoutes = (prefix, key, database, subscribers) => {
   const applicableSubscribers = defineSubscribers(subscribers, key);
   const handler = defineHandler(key, database, applicableSubscribers);
   const route = `${prefix ? `/${prefix}` : ''}/${key}`;
@@ -29,7 +29,7 @@ const defineRoutes = (prefix, key, schema, database, subscribers) => {
 export default config => {
   const subscribers = (config.subscribers || []).map(s => s.implementation);
   const routes = _.keys(config.database.models).map(key =>
-    defineRoutes(config.prefix, key, config.database.models[key], config.database, subscribers)
+    defineRoutes(config.prefix, key, config.database, subscribers)
   );
 
   return _.flattenDeep(routes);

--- a/src/load_routes.js
+++ b/src/load_routes.js
@@ -28,10 +28,8 @@ const defineRoutes = (prefix, key, schema, database, subscribers) => {
 // load route
 export default config => {
   const subscribers = (config.subscribers || []).map(s => s.implementation);
-
-  const routes = config.schema.map(({schema}) =>
-    _.keys(schema).map(key =>
-      defineRoutes(config.prefix, key, schema[key], config.database, subscribers))
+  const routes = _.keys(config.database.models).map(key =>
+    defineRoutes(config.prefix, key, config.database.models[key], config.database, subscribers)
   );
 
   return _.flattenDeep(routes);


### PR DESCRIPTION
This changes the route generator from looking at the schema itself, to looking at the full list of database models.  

That list contains the join table models, which need to be read in some cases.